### PR TITLE
Updated scoring system to balance guesses and score more fairly

### DIFF
--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -236,11 +236,11 @@ export function getScore(target, guesses) {
   });
 
   const closenessScore = Math.max(
-    ((maxTotalDifference - differenceSum) / maxTotalDifference) * 45,
+    ((maxTotalDifference - differenceSum) / maxTotalDifference) * 60,
     0
   );
   const closenessLogScore = Math.max(
-    ((maxTotalLogDifference - differenceLogSum) / maxTotalLogDifference) * 45,
+    ((maxTotalLogDifference - differenceLogSum) / maxTotalLogDifference) * 30,
     0
   );
 


### PR DESCRIPTION
The scoring system has a few sore points that this hopes to alleviate:
- The number of guesses is the primary lever for score right now, which is frustrating because there isn't really a skill based approach to limiting the number of guesses. The game is binary search after the initial guess, so it feels bad that a single ones column hunt can give you a 57% for the day
- The `maxTotalDifference` is a a linear function, which makes it a bad estimator of guess quality across all scores. It tends to be fairly compressed because it is trying to measure variance across the entirety of possibilities, which means players tend to have very similar scores regardless of input.


## This PR:
- Adds a logarithmic score portion, which makes it easier to tell the difference in small changes close to the real guess. This fixes the problem in the old scoring system where everything was in the 90-100% range. This also adds a faux minimum score for guesses, since further scores are basically all the same value.
- Zoomed in the linear portion of the score. `maxDifferencePerChannel` is now set to 64, so anything more than that is actually negative points, but this also helps alleviate the score compression problem in the old system
- Moved per guess scoring to 2% a guess. This is small, but it is nice to have a meaningful change in the score per guess, just to make players feel extra good for their lucky 2 or 3 guess day


Let me know what you guys think!


## Sample scores
<img width="685" alt="Screenshot 2024-04-09 at 3 25 11 PM" src="https://github.com/hannah-larsen/hexcodle/assets/28273666/d63d1fca-73e3-4bec-bacd-fb00dd9016cf">
